### PR TITLE
match return type of write with type in fs.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-KSRC = ~/kernel/ 
+KSRC = /usr/src/linux-headers-4.10.0-42-generic/
+#KSRC = /lib/modules/4.10.0-42-generic/build
 #KSRC = /home/z00228467/file/kernel-dev
 PWD = $(shell pwd)
 
@@ -10,7 +11,8 @@ obj-m := dfx.o
 dfx-objs := djtag/djtag.o proc/LLC.o proc/HHA.o proc/AA.o proc/PA.o proc/proc.o 
  
 default:
-	$(MAKE) -C $(KSRC) ARCH=arm64 M=$(PWD) LDDINC=$(PWD)/../include
+	./processType.sh $(KSRC)/include/linux/fs.h
+	$(MAKE) -C $(KSRC) M=$(PWD) LDDINC=$(PWD)/../include
 	#$(MAKE) -C $(KSRC) ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- M=$(PWD) LDDINC=$(PWD)/../include
 clean:
 	$(MAKE) -C $(KSRC) ARCH=arm64 M=$(PWD) clean

--- a/proc/proc.c
+++ b/proc/proc.c
@@ -78,8 +78,7 @@ void ni_sc_iounmap(void)
 
 
 
-size_t hi1616_dfx_write(struct file *file, const char __user *buf, size_t count, loff_t *ppos)
-//static int hi1616_dfx_write(struct file *file, const char __user *buf, size_t count, loff_t *ppos)
+static ssize_t hi1616_dfx_write(struct file *file, const char __user *buf, size_t count, loff_t *ppos)
 {
     char mbuf[100];
     char *p;

--- a/processType.sh
+++ b/processType.sh
@@ -3,10 +3,8 @@
 
 val=$(grep '(\*write)' $1 | awk '{print $1}')
 
-val=''
 
 if [[ $val == "" ]]; then
-	echo 'aaaaaaaaaaaaaaaaaaaaaaaa'
 	val='ssize_t'
 fi
 

--- a/processType.sh
+++ b/processType.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+
+val=$(grep '(\*write)' $1 | awk '{print $1}')
+
+
+sed -i -e "s/static .* hi1616_dfx_write/static ${val} hi1616_dfx_write/g" ./proc/proc.c
+

--- a/processType.sh
+++ b/processType.sh
@@ -1,8 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
 
 val=$(grep '(\*write)' $1 | awk '{print $1}')
 
+val=''
+
+if [[ $val == "" ]]; then
+	echo 'aaaaaaaaaaaaaaaaaaaaaaaa'
+	val='ssize_t'
+fi
 
 sed -i -e "s/static .* hi1616_dfx_write/static ${val} hi1616_dfx_write/g" ./proc/proc.c
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-0.安装与使用：https://github.com/YvesZHI/hi1616dfx/blob/master/manual.txt<br>
+0.安装与使用：https://github.com/YvesZHI/hi1616dfx/blob/master/manual.txt
 
 1.insmod dfx.ko（需要保证编译时使用内核和使用环境内核匹配，版本不一致时需重新编译）
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,20 +1,22 @@
-1.insmod dfx.ko£¨ÐèÒª±£Ö¤±àÒëÊ±Ê¹ÓÃÄÚºËºÍÊ¹ÓÃ»·¾³ÄÚºËÆ¥Åä£¬°æ±¾²»Ò»ÖÂÊ±ÐèÖØÐÂ±àÒë£©
+0.å®‰è£…ä¸Žä½¿ç”¨ï¼šhttps://github.com/YvesZHI/hi1616dfx/blob/master/manual.txt<br>
 
-2.ÅäÖÃ²ÎÊý£¨²âÊÔÀàÐÍºÍ²âÊÔÊ±¼ä£©£¬ÒÔecho "1 10" > /proc/HI1616_DFXÐÎÊ½ÅäÖÃ£¬1ÎªÀàÐÍ£¬±íÊ¾DDRºÍLLC£¬10±íÊ¾Ê±¼äÎª10Ãë£¬½á¹ûÊä³öÔÚ/homeÏÂ
-²âÊÔÀàÐÍ¶ÔÕÕÈçÏÂ£º
-²ÎÊý£ºÀàÐÍ£ºÊä³öÂ·¾¶
-1£ºDDRºÍLLC£º/home/llc_ddr_statistic£º
-2£ºHHAºÍSLLC£º/home/hha_sllc_statisticÃ¿ÐÐ12¸öÊý¾Ý£¬¶ÔÓ¦12¸öÊÂ¼þµÄÍ³¼Æ½á¹û£¬ÕûÀíºóÊä³ö²»Ðè¾­¹ý¹«Ê½×ª»»£»SLLC£¬Ã¿ÐÐ4¸öÊý¾Ý£¬±íÊ¾TX²àrequest¡¢snoop¡¢response¡¢dataÍ¨µÀpacket¼ÆÊý¼Ä´æÆ÷
-3£ºAA read£º/home/aa_rd_statistic
-4£ºAA write£º/home/aa_wr_statistic£º
-5: AA copyback£º/home/aa_cb_statistic
-6: PAºÍHLLC£º/home/pa_statistic£º
+1.insmod dfx.koï¼ˆéœ€è¦ä¿è¯ç¼–è¯‘æ—¶ä½¿ç”¨å†…æ ¸å’Œä½¿ç”¨çŽ¯å¢ƒå†…æ ¸åŒ¹é…ï¼Œç‰ˆæœ¬ä¸ä¸€è‡´æ—¶éœ€é‡æ–°ç¼–è¯‘ï¼‰
 
-3.ÕûÀíÊý¾Ý
-python parse.py -c ²âÊÔÌõ¼þ -t Ê±¼ä  -o Êä³öÎÄ¼þÃû
+2.é…ç½®å‚æ•°ï¼ˆæµ‹è¯•ç±»åž‹å’Œæµ‹è¯•æ—¶é—´ï¼‰ï¼Œä»¥echo "1 10" > /proc/HI1616_DFXå½¢å¼é…ç½®ï¼Œ1ä¸ºç±»åž‹ï¼Œè¡¨ç¤ºDDRå’ŒLLCï¼Œ10è¡¨ç¤ºæ—¶é—´ä¸º10ç§’ï¼Œç»“æžœè¾“å‡ºåœ¨/homeä¸‹
+æµ‹è¯•ç±»åž‹å¯¹ç…§å¦‚ä¸‹ï¼š
+å‚æ•°ï¼šç±»åž‹ï¼šè¾“å‡ºè·¯å¾„
+1ï¼šDDRå’ŒLLCï¼š/home/llc_ddr_statisticï¼š
+2ï¼šHHAå’ŒSLLCï¼š/home/hha_sllc_statisticæ¯è¡Œ12ä¸ªæ•°æ®ï¼Œå¯¹åº”12ä¸ªäº‹ä»¶çš„ç»Ÿè®¡ç»“æžœï¼Œæ•´ç†åŽè¾“å‡ºä¸éœ€ç»è¿‡å…¬å¼è½¬æ¢ï¼›SLLCï¼Œæ¯è¡Œ4ä¸ªæ•°æ®ï¼Œè¡¨ç¤ºTXä¾§requestã€snoopã€responseã€dataé€šé“packetè®¡æ•°å¯„å­˜å™¨
+3ï¼šAA readï¼š/home/aa_rd_statistic
+4ï¼šAA writeï¼š/home/aa_wr_statisticï¼š
+5: AA copybackï¼š/home/aa_cb_statistic
+6: PAå’ŒHLLCï¼š/home/pa_statisticï¼š
 
-²âÊÔÌõ¼þ£º
-1£©aa_cb
+3.æ•´ç†æ•°æ®
+python parse.py -c æµ‹è¯•æ¡ä»¶ -t æ—¶é—´  -o è¾“å‡ºæ–‡ä»¶å
+
+æµ‹è¯•æ¡ä»¶ï¼š
+1ï¼‰aa_cb
 2)aa_rd
 3)aa_wr
 4)hha
@@ -22,16 +24,16 @@ python parse.py -c ²âÊÔÌõ¼þ -t Ê±¼ä  -o Êä³öÎÄ¼þÃû
 6)llc
 7)pa
 9)sllc
-Ê±¼ä£º
-ºÍ2ÖÐ²âÊÔÊ±¼ä±£³ÖÒ»ÖÂ
+æ—¶é—´ï¼š
+å’Œ2ä¸­æµ‹è¯•æ—¶é—´ä¿æŒä¸€è‡´
 
-4.ÕûÀíÊý¾ÝÊä³ö¸ñÊ½
-ÀàÐÍ£ºÊä³öÊý¾Ý£ºÕûÀíºóÊä³ö¸ñÊ½
-DDR£ºÃ¿ÐÐÊý¾ÝÒÀÇé¿ö¶ø¶¨£¬ÒÀ´ÎÎªDDR0 wr,DDR0 rd,DDR1 wr,DDR1 rd¡­£ºÕûÀíºóÊä³öÒªÇóÎª´ø¿íÍ³¼Æ£¬¿ÉÓÃDDRÖÐÍ³¼Æ½á¹û³ËÒÔ32£¬×ª»»Îªbyte/s£¬¾­parse.pyÕûÀíºóµ¥Î»ÎªMB/s
-LLC£ºÃ¿ÐÐ8¸öÊý¾Ý£¬Ö»Ðè¹Ø×¢Ç°6¸ö£¬¶ÔÓ¦ÐèÇóÁÐ±íÖÐµÄ6¸öÍ³¼Æ½á¹û£ºÕûÀíºóÊä³öÎª¶ÁÃüÖÐÂÊ4/(0+2)£¬Ð´ÃüÖÐÂÊ5/(1+3)£¬£¨¼ÆËã¹«Ê½ÖÐÊý×Ö±íÊ¾6¸öÍ³¼Æ½á¹ûµÄÐòºÅ£©
-HHA£ºÃ¿ÐÐ12¸öÊý¾Ý£¬¶ÔÓ¦12¸öÊÂ¼þµÄÍ³¼Æ½á¹û£ºÕûÀíºóÊä³ö²»Ðè¾­¹ý¹«Ê½×ª»»
-SLLC£ºÃ¿ÐÐ4¸öÊý¾Ý£¬±íÊ¾TX²àrequest¡¢snoop¡¢response¡¢dataÍ¨µÀpacket¼ÆÊý¼Ä´æÆ÷£ºÕûÀíºóÊä³öÒªÇóÎª´ø¿íÍ³¼Æ£¬¿ÉÓÃ¸÷ÏîÍ³¼Æ½á¹û³ËÒÔ16£¬×ª»»Îªbyte/s£¬¾­parse.pyÕûÀíºóµ¥Î»ÎªMB/s
-AA£ºÃ¿ÐÐ°üÀ¨4¸öAAµÄÑÓÊ±£¨Æ½¾ùÑÓÊ±¡¢²ÉÑù¸öÊý¡¢×î´óÑÓÊ±£©£¬ÑÓÊ±µ¥Î»Îªcycle£¬ÕûÀíºóÊä³öÎªÆ½¾ùÑÓÊ±ºÍ×î´óÑÓÊ±
-PA£ºÃ¿ÐÐ°üÀ¨RX²àHydra Port0µÄrequest¡¢snoop¡¢response¡¢dataÍ¨µÀ¼ÆÊý£¬Hydra Port1µÄ£¬Hydra port2µÄ¡­¡­£ºÕûÀíºóÊä³ö²»Ðè¾­¹ý¹«Ê½×ª»»
-HLLC£ºÃ¿ÐÐ°üº¬8¸öÊý¾Ý£¬·Ö±ðÎªchannel0,1,2,3µÄPA·¢ËÍ¸øHLLCµÄflit¼ÆÊý£¬channel0,1,2,3µÄHLLC·¢¸øPAµÄflit¼ÆÊý£ºÕûÀíºóÊä³öÒªÇóÎª´ø¿íÍ³¼Æ£¬¿ÉÓÃ¸÷ÏîÍ³¼Æ½á¹û³ËÒÔ16£¬×ª»»Îªbyte/s£¬¾­parse.pyÕûÀíºóµ¥Î»ÎªMB/s
+4.æ•´ç†æ•°æ®è¾“å‡ºæ ¼å¼
+ç±»åž‹ï¼šè¾“å‡ºæ•°æ®ï¼šæ•´ç†åŽè¾“å‡ºæ ¼å¼
+DDRï¼šæ¯è¡Œæ•°æ®ä¾æƒ…å†µè€Œå®šï¼Œä¾æ¬¡ä¸ºDDR0 wr,DDR0 rd,DDR1 wr,DDR1 rdâ€¦ï¼šæ•´ç†åŽè¾“å‡ºè¦æ±‚ä¸ºå¸¦å®½ç»Ÿè®¡ï¼Œå¯ç”¨DDRä¸­ç»Ÿè®¡ç»“æžœä¹˜ä»¥32ï¼Œè½¬æ¢ä¸ºbyte/sï¼Œç»parse.pyæ•´ç†åŽå•ä½ä¸ºMB/s
+LLCï¼šæ¯è¡Œ8ä¸ªæ•°æ®ï¼Œåªéœ€å…³æ³¨å‰6ä¸ªï¼Œå¯¹åº”éœ€æ±‚åˆ—è¡¨ä¸­çš„6ä¸ªç»Ÿè®¡ç»“æžœï¼šæ•´ç†åŽè¾“å‡ºä¸ºè¯»å‘½ä¸­çŽ‡4/(0+2)ï¼Œå†™å‘½ä¸­çŽ‡5/(1+3)ï¼Œï¼ˆè®¡ç®—å…¬å¼ä¸­æ•°å­—è¡¨ç¤º6ä¸ªç»Ÿè®¡ç»“æžœçš„åºå·ï¼‰
+HHAï¼šæ¯è¡Œ12ä¸ªæ•°æ®ï¼Œå¯¹åº”12ä¸ªäº‹ä»¶çš„ç»Ÿè®¡ç»“æžœï¼šæ•´ç†åŽè¾“å‡ºä¸éœ€ç»è¿‡å…¬å¼è½¬æ¢
+SLLCï¼šæ¯è¡Œ4ä¸ªæ•°æ®ï¼Œè¡¨ç¤ºTXä¾§requestã€snoopã€responseã€dataé€šé“packetè®¡æ•°å¯„å­˜å™¨ï¼šæ•´ç†åŽè¾“å‡ºè¦æ±‚ä¸ºå¸¦å®½ç»Ÿè®¡ï¼Œå¯ç”¨å„é¡¹ç»Ÿè®¡ç»“æžœä¹˜ä»¥16ï¼Œè½¬æ¢ä¸ºbyte/sï¼Œç»parse.pyæ•´ç†åŽå•ä½ä¸ºMB/s
+AAï¼šæ¯è¡ŒåŒ…æ‹¬4ä¸ªAAçš„å»¶æ—¶ï¼ˆå¹³å‡å»¶æ—¶ã€é‡‡æ ·ä¸ªæ•°ã€æœ€å¤§å»¶æ—¶ï¼‰ï¼Œå»¶æ—¶å•ä½ä¸ºcycleï¼Œæ•´ç†åŽè¾“å‡ºä¸ºå¹³å‡å»¶æ—¶å’Œæœ€å¤§å»¶æ—¶
+PAï¼šæ¯è¡ŒåŒ…æ‹¬RXä¾§Hydra Port0çš„requestã€snoopã€responseã€dataé€šé“è®¡æ•°ï¼ŒHydra Port1çš„ï¼ŒHydra port2çš„â€¦â€¦ï¼šæ•´ç†åŽè¾“å‡ºä¸éœ€ç»è¿‡å…¬å¼è½¬æ¢
+HLLCï¼šæ¯è¡ŒåŒ…å«8ä¸ªæ•°æ®ï¼Œåˆ†åˆ«ä¸ºchannel0,1,2,3çš„PAå‘é€ç»™HLLCçš„flitè®¡æ•°ï¼Œchannel0,1,2,3çš„HLLCå‘ç»™PAçš„flitè®¡æ•°ï¼šæ•´ç†åŽè¾“å‡ºè¦æ±‚ä¸ºå¸¦å®½ç»Ÿè®¡ï¼Œå¯ç”¨å„é¡¹ç»Ÿè®¡ç»“æžœä¹˜ä»¥16ï¼Œè½¬æ¢ä¸ºbyte/sï¼Œç»parse.pyæ•´ç†åŽå•ä½ä¸ºMB/s
 


### PR DESCRIPTION
The current version is not compatible because of the return type of `hi1616_dfx_write` (line 81 in proc/proc.c) doesn't match with the relative type in linux/fs.h.

If making them match automatically is not considerable, ignore this pull request please.